### PR TITLE
Updating packages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,13 +2,13 @@
 buildscript {
     repositories {
         google()
-        jcenter()
         mavenCentral()
         mavenLocal()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.0.1")
+        classpath("com.android.tools.build:gradle:4.0.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21")
+        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.6.10")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Jcenter has been deprecated and is to be replaced with mavenCentral() - https://stackoverflow.com/questions/66651640/jcenter-deprecation-impact-on-gradle-and-android

Updated gradle and added a defined dokka install
